### PR TITLE
Remove 'virt: lxd' to fix issues in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-virt: lxd   # LXD containers where possible as they boot much faster than full VMs
 os: linux   # required for arch different than amd64
 dist: focal # newest available distribution
 
@@ -79,7 +78,9 @@ jobs:
       if: 'NOT tag =~ /^docker-/'
     - stage: test
       name: "Run unit and integration tests including Docker [arm64]"
-      arch: arm64 # Not arm64-graviton2 as it cycles on boot for a long time before running [2020-11-02]
+      arch: arm64-graviton2
+      virt: lxd   # LXD containers where possible as they boot much faster than full VMs
+      group: edge
       # We run tests on non-tagged pushes to master that aren't commit made by the release plugin
       # We also run tests on pull requests targeted at the master branch.
       if: |


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**1. Patch Details:** Following file has been modified :

.travis.yml: 'virt: lxd' has been removed.

**2. Testing Detail:**
Please find my Travis-ci testing jobs here: https://travis-ci.com/github/ra9501576600git/zipkin/builds/199577772

**3. PR Description:** Here is my commit message :

Travis build environment is already set to 'lxd' by-default. 'virt: lxd' or 'virt: vm' is only required while working with 'arch: arm64-graviton2'

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Reviewer:** Pruthvi Teja Reddy & Shobhit Parashari

**Thanks
Rahul Aggarwal**